### PR TITLE
fix: normalize controller icon asset paths on Windows

### DIFF
--- a/src/icons.rs
+++ b/src/icons.rs
@@ -260,6 +260,20 @@ pub struct ControllerIconAssets {
     icons: std::collections::HashMap<(ButtonIcon, ControllerLayout, IconSize), Handle<Image>>,
 }
 
+fn build_asset_path(base_path: &str, filename: &str) -> String {
+    let normalized_base = base_path.replace('\\', "/");
+    let trimmed_base = normalized_base.trim_end_matches('/');
+
+    let normalized_filename = filename.replace('\\', "/");
+    let trimmed_filename = normalized_filename.trim_start_matches('/');
+
+    if trimmed_base.is_empty() {
+        trimmed_filename.to_string()
+    } else {
+        format!("{trimmed_base}/{trimmed_filename}")
+    }
+}
+
 impl ControllerIconAssets {
     /// Create a new icon assets resource with a base path.
     #[must_use]
@@ -285,7 +299,7 @@ impl ControllerIconAssets {
             return handle.clone();
         }
 
-        let path = format!("{}/{}", self.base_path, icon.filename(layout, size));
+        let path = build_asset_path(&self.base_path, &icon.filename(layout, size));
         let handle = asset_server.load(&path);
         self.icons.insert(key, handle.clone());
         handle
@@ -665,3 +679,37 @@ mod tests {
         assert_eq!(assets.base_path, "custom/path/icons");
     }
 }
+
+    #[test]
+    fn test_build_asset_path_normalizes_windows_separators() {
+        // Windows paths with backslashes should be normalized to forward slashes
+        assert_eq!(
+            build_asset_path("assets\\icons", "xbox_a.png"),
+            "assets/icons/xbox_a.png"
+        );
+        assert_eq!(
+            build_asset_path("assets\\icons\\", "xbox_a.png"),
+            "assets/icons/xbox_a.png"
+        );
+        assert_eq!(
+            build_asset_path("assets/icons", "xbox_a.png"),
+            "assets/icons/xbox_a.png"
+        );
+    }
+
+    #[test]
+    fn test_build_asset_path_trims_extra_separators() {
+        // Extra separators should be trimmed
+        assert_eq!(
+            build_asset_path("assets/icons/", "/xbox_a.png"),
+            "assets/icons/xbox_a.png"
+        );
+        assert_eq!(
+            build_asset_path("", "xbox_a.png"),
+            "xbox_a.png"
+        );
+        assert_eq!(
+            build_asset_path("assets/icons", "xbox_a.png"),
+            "assets/icons/xbox_a.png"
+        );
+    }

--- a/src/motion/dualsense.rs
+++ b/src/motion/dualsense.rs
@@ -161,7 +161,7 @@ impl MotionBackend for DualSenseBackend {
     }
 
     fn is_connected(&self) -> bool {
-        self.state.lock().map(|s| s.connected).unwrap_or(false)
+        self.state.lock().is_ok_and(|s| s.connected)
     }
 
     fn name(&self) -> &'static str {


### PR DESCRIPTION
Adds Windows path compatibility by normalizing backslashes to forward slashes and trimming extra separators in icon asset paths. This ensures controller icons load correctly on Windows.