### PR TITLE
chore: ignore .coraline artifacts on main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ docs/
 !docs/HARDWARE_INTEGRATION_GUIDE.md
 !docs/TEST_COVERAGE.md
 !docs/assets/
+
+.coraline/


### PR DESCRIPTION
Adds .coraline/ to .gitignore so local Coraline workspace artifacts are never tracked.