### PR TITLE
chore: ignore .coraline artifacts on bevy-0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ docs/
 !docs/HARDWARE_INTEGRATION_GUIDE.md
 !docs/TEST_COVERAGE.md
 !docs/assets/
+
+.coraline/


### PR DESCRIPTION
Adds .coraline/ to .gitignore so local Coraline workspace artifacts are never tracked.