### PR TITLE
chore: propagate rust-toolchain to bevy-0.17

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.95.0"


### PR DESCRIPTION
Propagates rust-toolchain.toml from active working branch and removes accidental backup artifact src/motion/dualsense.rs.bak2 if present.