### PR TITLE
feat: upgrade to Bevy 0.19 with FontSource typography

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@
 # Branch Strategy:
 # - main: Latest stable Bevy line (currently 0.19)
 # - bevy-0.18: Maintenance branch for Bevy 0.18.x
-# - bevy-0.17: Deprecated maintenance branch for Bevy 0.17.x
 
 version: 2
 updates:
@@ -47,34 +46,6 @@ updates:
           - "patch"
         exclude-patterns:
           - "bevy*"
-
-  # Dependabot for bevy-0.17 maintenance branch
-  - package-ecosystem: "cargo"
-    directory: "/"
-    target-branch: "bevy-0.17"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/New_York"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "deps(cargo)"
-    labels:
-      - "dependencies"
-      - "rust"
-      - "bevy-0.17"
-    ignore:
-      - dependency-name: "bevy"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "bevy-*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    groups:
-      all-patches:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,9 @@
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
 #
 # Branch Strategy:
-# - main: Latest stable Bevy line (currently 0.18)
-# - bevy-0.17: Maintenance branch for Bevy 0.17.x
+# - main: Latest stable Bevy line (currently 0.19)
+# - bevy-0.18: Maintenance branch for Bevy 0.18.x
+# - bevy-0.17: Deprecated maintenance branch for Bevy 0.17.x
 
 version: 2
 updates:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -22,7 +22,7 @@ jobs:
       # an attacker who controls a previous run. Since we already gate on
       # head_branch == 'main', main's HEAD is the same merge commit and the
       # tag/commit we operate on.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -43,7 +43,13 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         id: version
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "bevy_archie") | .version')
+          # Parse version directly from Cargo.toml to avoid requiring a full
+          # Rust toolchain install for this single metadata call.
+          VERSION=$(awk -F'"' '/^version[[:space:]]*=/ {print $2; exit}' Cargo.toml)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not parse version from Cargo.toml"
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,99 @@
+name: Auto-tag on version bump
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+# Default-deny: tag job expands to contents:write and actions:write.
+permissions: {}
+
+jobs:
+  tag:
+    name: Push version tag if missing
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      # Check out main rather than the workflow_run head_sha: a workflow_run
+      # event is triggered by another workflow and its head_sha can be set by
+      # an attacker who controls a previous run. Since we already gate on
+      # head_branch == 'main', main's HEAD is the same merge commit and the
+      # tag/commit we operate on.
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Gate on version-bump commit
+        id: gate
+        run: |
+          msg="$(git log -1 --pretty=%s)"
+          if [[ "$msg" == chore:*bump\ version* ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Head commit message does not match 'chore: bump version ...' pattern"
+          fi
+
+      - name: Extract version from Cargo.toml
+        if: steps.gate.outputs.run == 'true'
+        id: version
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "bevy_archie") | .version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        if: steps.gate.outputs.run == 'true'
+        id: check
+        run: |
+          if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push tag
+        if: steps.gate.outputs.run == 'true' && steps.check.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "${{ steps.version.outputs.tag }}"
+          if git push origin "${{ steps.version.outputs.tag }}"; then
+            echo "Pushed ${{ steps.version.outputs.tag }}"
+            exit 0
+          fi
+
+          # If a manual push raced us, treat that as success.
+          if git ls-remote --tags origin "refs/tags/${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "Tag ${{ steps.version.outputs.tag }} was created concurrently; continuing"
+            exit 0
+          fi
+          echo "Failed to push tag ${{ steps.version.outputs.tag }}"
+          exit 1
+
+      - name: Trigger release workflow
+        if: steps.gate.outputs.run == 'true' && steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml \
+            --ref "${{ steps.version.outputs.tag }}" \
+            -f tag="${{ steps.version.outputs.tag }}"
+
+      - name: Tag already exists
+        if: steps.gate.outputs.run == 'true' && steps.check.outputs.exists == 'true'
+        run: |
+          echo "Tag ${{ steps.version.outputs.version }} already exists, skipping"
+
+      - name: Not a version-bump commit
+        if: steps.gate.outputs.run != 'true'
+        run: |
+          echo "Skipping auto-tag: head commit is not a version-bump commit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, bevy-0.19, bevy-0.18, bevy-0.17]
+    branches: [main, bevy-0.19, bevy-0.18]
   pull_request:
-    branches: [main, bevy-0.19, bevy-0.18, bevy-0.17]
+    branches: [main, bevy-0.19, bevy-0.18]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -52,7 +52,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -96,7 +96,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -154,7 +154,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -168,7 +168,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -207,7 +207,7 @@ jobs:
     name: Minimum Supported Rust Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain (MSRV)
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Install Rust toolchain (MSRV)
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.96"
 
       - name: Install system dependencies
         run: |
@@ -270,7 +270,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, bevy-0.17]
+    branches: [main, bevy-0.18, bevy-0.17] 
   pull_request:
-    branches: [main, bevy-0.17]
+    branches: [main, bevy-0.18, bevy-0.17] 
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,28 @@ name: CI
 
 on:
   push:
-    branches: [main, bevy-0.18, bevy-0.17] 
+    branches: [main, bevy-0.19, bevy-0.18, bevy-0.17]
   pull_request:
-    branches: [main, bevy-0.18, bevy-0.17] 
+    branches: [main, bevy-0.19, bevy-0.18, bevy-0.17]
 
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
 
+# Default-deny: each job opts in to the minimum permissions it needs.
+permissions: {}
+
+# Cancel superseded PR runs but never cancel pushes to protected branches.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -51,6 +61,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -153,6 +165,8 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -167,6 +181,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -206,6 +222,8 @@ jobs:
   msrv:
     name: Minimum Supported Rust Version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -241,3 +259,21 @@ jobs:
 
       - name: Check MSRV
         run: cargo check --all-features
+
+  cross-platform:
+    name: Test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run tests
+        run: cargo test --features motion-backends

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, bevy-0.17]
+    branches: [main, bevy-0.18, bevy-0.17] 
   pull_request:
-    branches: [main, bevy-0.17]
+    branches: [main, bevy-0.18, bevy-0.17] 
   schedule:
     # Run weekly on Sunday at midnight UTC
     - cron: "0 0 * * 0"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,13 +2,14 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, bevy-0.19, bevy-0.18, bevy-0.17]
+    branches: [main, bevy-0.19, bevy-0.18]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
       - "**/Cargo.lock"
       - ".github/workflows/codeql.yml"
   pull_request:
+    branches: [main, bevy-0.19, bevy-0.18]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,12 +2,29 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, bevy-0.18, bevy-0.17] 
+    branches: [main, bevy-0.19, bevy-0.18, bevy-0.17]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/codeql.yml"
   pull_request:
-    branches: [main, bevy-0.18, bevy-0.17] 
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/codeql.yml"
   schedule:
     # Run weekly on Sunday at midnight UTC
     - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+# Default-deny: the analysis job needs security-events: write to upload SARIF.
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,23 +1,24 @@
 name: Auto-merge Dependabot PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+# Default-deny: the auto-merge job opts in to write permissions.
+# pull_request_target (vs pull_request) is required for the gh CLI to
+# have write access to enable auto-merge.
+permissions: {}
 
 jobs:
   dependabot-auto-merge:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v3
@@ -33,7 +34,12 @@ jobs:
 
       - name: Enable auto-merge for patch updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          if gh pr merge --auto --squash "$PR_URL"; then
+            echo "Auto-merge enabled for patch update"
+          else
+            echo "::warning::Could not enable auto-merge. Enable 'Allow auto-merge' in repository settings (Settings → General → Pull Requests) to activate this workflow."
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,7 +48,11 @@ jobs:
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: |
           gh pr comment "$PR_URL" --body "✅ **Auto-approved** - This is a minor version update. Will auto-merge once CI passes."
-          gh pr merge --auto --squash "$PR_URL"
+          if gh pr merge --auto --squash "$PR_URL"; then
+            echo "Auto-merge enabled for minor update"
+          else
+            echo "::warning::Could not enable auto-merge. Enable 'Allow auto-merge' in repository settings (Settings → General → Pull Requests) to activate this workflow."
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Fetch the tag's commit, not just the default branch
           ref: ${{ github.ref }}
@@ -70,7 +70,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Fetch the tag's commit for correct CHANGELOG extraction
           ref: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,36 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.3.0)"
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
+
+# Default-deny: each job opts in to the minimum permissions it needs.
+permissions: {}
+
+# Don't run two releases for the same tag in parallel.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
           # Fetch the tag's commit, not just the default branch
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -59,9 +76,28 @@ jobs:
         run: cargo publish --dry-run
 
       - name: Publish to crates.io
-        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -o pipefail
+          log=$(mktemp)
+          trap 'rm -f "$log"' EXIT
+
+          # Race-tolerant publish: a parallel/concurrent publish or a stale
+          # crates.io index can cause "already exists" between pre-checks and
+          # the actual upload. Treat that single error as a success.
+          if cargo publish 2>&1 | tee "$log"; then
+            echo "bevy_archie@${GITHUB_REF#refs/tags/v} published successfully"
+            exit 0
+          fi
+
+          if grep -qE "already exists on crates.io" "$log"; then
+            echo "bevy_archie@${GITHUB_REF#refs/tags/v} already published (treating as success)"
+            exit 0
+          fi
+
+          echo "::error::cargo publish failed"
+          exit 1
 
   github-release:
     name: Create GitHub Release
@@ -74,6 +110,7 @@ jobs:
         with:
           # Fetch the tag's commit for correct CHANGELOG extraction
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Extract changelog for this version
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,17 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # workflow_dispatch receives a `tag` input but `github.ref` still points at
+  # the branch you dispatched from, so synthesize refs/tags/<tag> for that path.
+  # For tag pushes `github.ref` is already refs/tags/<tag>.
+  RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
 
 # Default-deny: each job opts in to the minimum permissions it needs.
 permissions: {}
 
 # Don't run two releases for the same tag in parallel.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ env.RELEASE_REF }}
   cancel-in-progress: false
 
 jobs:
@@ -32,7 +36,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           # Fetch the tag's commit, not just the default branch
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_REF }}
           persist-credentials: false
 
       - name: Install Rust toolchain
@@ -66,7 +70,7 @@ jobs:
       - name: Verify version matches tag
         run: |
           CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          TAG_VERSION="${RELEASE_REF#refs/tags/v}"
           if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: Cargo.toml has $CARGO_VERSION, tag is $TAG_VERSION"
             exit 1
@@ -87,12 +91,12 @@ jobs:
           # crates.io index can cause "already exists" between pre-checks and
           # the actual upload. Treat that single error as a success.
           if cargo publish 2>&1 | tee "$log"; then
-            echo "bevy_archie@${GITHUB_REF#refs/tags/v} published successfully"
+            echo "bevy_archie@${RELEASE_REF#refs/tags/v} published successfully"
             exit 0
           fi
 
           if grep -qE "already exists on crates.io" "$log"; then
-            echo "bevy_archie@${GITHUB_REF#refs/tags/v} already published (treating as success)"
+            echo "bevy_archie@${RELEASE_REF#refs/tags/v} already published (treating as success)"
             exit 0
           fi
 
@@ -109,13 +113,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           # Fetch the tag's commit for correct CHANGELOG extraction
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_REF }}
           persist-credentials: false
 
       - name: Extract changelog for this version
         id: changelog
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="${RELEASE_REF#refs/tags/v}"
           # Extract section for this version from CHANGELOG.md
           NOTES=$(awk "/^## \[?$VERSION\]?/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md)
           echo "notes<<EOF" >> $GITHUB_OUTPUT
@@ -127,6 +131,6 @@ jobs:
         with:
           body: ${{ steps.changelog.outputs.notes }}
           draft: false
-          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+          prerelease: ${{ contains(env.RELEASE_REF, '-alpha') || contains(env.RELEASE_REF, '-beta') || contains(env.RELEASE_REF, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -29,7 +29,7 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,13 +2,14 @@ name: Security Audit
 
 on:
   push:
-    branches: [main, bevy-0.19, bevy-0.18, bevy-0.17]
+    branches: [main, bevy-0.19, bevy-0.18]
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
       - "deny.toml"
       - ".github/workflows/security.yml"
   pull_request:
+    branches: [main, bevy-0.19, bevy-0.18]
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,17 +2,37 @@ name: Security Audit
 
 on:
   push:
-    branches: [main, bevy-0.18, bevy-0.17] 
+    branches: [main, bevy-0.19, bevy-0.18, bevy-0.17]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/security.yml"
   pull_request:
-    branches: [main, bevy-0.18, bevy-0.17] 
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/security.yml"
   schedule:
     # Run weekly on Monday at 9 AM UTC
     - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+# Default-deny: each job opts in to the minimum permissions it needs.
+permissions: {}
+
+# Avoid running duplicate audits when PRs are pushed rapidly.
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -20,7 +40,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --locked
 
       - name: Run security audit
         run: cargo audit --ignore RUSTSEC-2024-0436
@@ -28,6 +48,8 @@ jobs:
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -35,7 +57,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        run: cargo install cargo-deny --locked
 
       - name: Check licenses
         run: cargo deny check --config deny.toml licenses

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security Audit
 
 on:
   push:
-    branches: [main, bevy-0.17]
+    branches: [main, bevy-0.18, bevy-0.17] 
   pull_request:
-    branches: [main, bevy-0.17]
+    branches: [main, bevy-0.18, bevy-0.17] 
   schedule:
     # Run weekly on Monday at 9 AM UTC
     - cron: "0 9 * * 1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Bevy 0.18 → 0.19 upgrade**: Migrated to Bevy 0.19 across the library, examples, and tests.
   - Bumped `bevy` dependency (library and dev) from `0.18` to `0.19` in `Cargo.toml`.
+  - Bumped `rust-version` from `1.94` to `1.96` to match the Bevy 0.19 line and align with the stable Rust toolchain.
   - Updated all example `TextFont { font_size: N.N, .. }` literals to the new `FontSize::Px(N.N)` enum form introduced by the Bevy text Parley migration. The `font` field now flows through `FontSource` and existing `..default()` usage continues to work via `From<Handle<Font>>`.
-- **Branch policy clarified**: `main` is explicitly documented as the Bevy 0.18.x line, with `bevy-0.17` as the only remaining support branch scheduled for retirement on 2026-05-18.
-- **CI scope reduced**: `.github/workflows/ci.yml` now runs for `main` and `bevy-0.17` only.
-- **Branch workflow docs aligned**: Updated branch strategy, backport notes, MSRV notes, and release command examples in `docs/dev/BRANCH_WORKFLOW.md`.
-- **README policy update**: Updated support messaging and version compatibility notes to match the two-branch model.
+- **Branch policy clarified**: `main` is now the Bevy 0.19.x line; `bevy-0.18` is the maintenance branch (Bevy 0.18.x); `bevy-0.17` remains published but is deprecated.
+- **CI scope reduced**: `.github/workflows/ci.yml` now runs for `main`, `bevy-0.19`, `bevy-0.18`, and `bevy-0.17`.
+- **Branch workflow docs aligned**: Updated branch strategy, backport notes (now covering both `bevy-0.18` and `bevy-0.17`), MSRV notes, and release command examples in `docs/dev/BRANCH_WORKFLOW.md`.
+- **README policy update**: Updated support messaging and version compatibility notes to reflect the three-branch model (`main` / `bevy-0.18` / `bevy-0.17`).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Bevy 0.18 → 0.19 upgrade**: Migrated to Bevy 0.19 across the library, examples, and tests.
+  - Bumped `bevy` dependency (library and dev) from `0.18` to `0.19` in `Cargo.toml`.
+  - Updated all example `TextFont { font_size: N.N, .. }` literals to the new `FontSize::Px(N.N)` enum form introduced by the Bevy text Parley migration. The `font` field now flows through `FontSource` and existing `..default()` usage continues to work via `From<Handle<Font>>`.
 - **Branch policy clarified**: `main` is explicitly documented as the Bevy 0.18.x line, with `bevy-0.17` as the only remaining support branch scheduled for retirement on 2026-05-18.
 - **CI scope reduced**: `.github/workflows/ci.yml` now runs for `main` and `bevy-0.17` only.
 - **Branch workflow docs aligned**: Updated branch strategy, backport notes, MSRV notes, and release command examples in `docs/dev/BRANCH_WORKFLOW.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bumped `bevy` dependency (library and dev) from `0.18` to `0.19` in `Cargo.toml`.
   - Bumped `rust-version` from `1.94` to `1.96` to match the Bevy 0.19 line and align with the stable Rust toolchain.
   - Updated all example `TextFont { font_size: N.N, .. }` literals to the new `FontSize::Px(N.N)` enum form introduced by the Bevy text Parley migration. The `font` field now flows through `FontSource` and existing `..default()` usage continues to work via `From<Handle<Font>>`.
-- **Branch policy clarified**: `main` is now the Bevy 0.19.x line; `bevy-0.18` is the maintenance branch (Bevy 0.18.x); `bevy-0.17` remains published but is deprecated.
-- **CI scope reduced**: `.github/workflows/ci.yml` now runs for `main`, `bevy-0.19`, `bevy-0.18`, and `bevy-0.17`.
-- **Branch workflow docs aligned**: Updated branch strategy, backport notes (now covering both `bevy-0.18` and `bevy-0.17`), MSRV notes, and release command examples in `docs/dev/BRANCH_WORKFLOW.md`.
-- **README policy update**: Updated support messaging and version compatibility notes to reflect the three-branch model (`main` / `bevy-0.18` / `bevy-0.17`).
+- **Branch policy clarified**: `main` is now the Bevy 0.19.x line; `bevy-0.18` is the maintenance branch (Bevy 0.18.x). The `bevy-0.17` branch has been retired (final 0.1.x releases remain on crates.io).
+- **CI scope reduced**: `.github/workflows/ci.yml` now runs for `main`, `bevy-0.19`, and `bevy-0.18`.
+- **Branch workflow docs aligned**: Updated branch strategy, backport notes (covering `bevy-0.18`), MSRV notes, and release command examples in `docs/dev/BRANCH_WORKFLOW.md`.
+- **README policy update**: Updated support messaging and version compatibility notes to reflect the two-branch model (`main` / `bevy-0.18`).
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to bevy-archie! This document provid
 
 ### Prerequisites
 
-- Rust 1.85 or later (see `rust-version` in Cargo.toml)
+- Rust 1.96 or later (see `rust-version` in Cargo.toml)
 - System dependencies for Bevy:
   - **Linux**: `libudev-dev libasound2-dev`
   - **macOS**: No additional dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ bevy = { version = "0.19", default-features = false, features = [
     "bevy_text",
     "bevy_sprite",
     "bevy_state",
+    "bevy_scene",
+    "bevy_settings",
 ] }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_archie"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.94"
 description = "A comprehensive game controller support module for Bevy"
@@ -29,7 +29,7 @@ dualsense = ["motion-backends", "dep:dualsense-rs"]
 full = ["icons", "virtual_keyboard", "remapping"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "std",
     "bevy_gilrs",
     "bevy_render",
@@ -53,7 +53,7 @@ dualsense-rs = { version = "0.6", optional = true }
 # steamworks = "0.11"  # For steam_touchpad (requires Steam client)
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = true }
+bevy = { version = "0.19", default-features = true }
 approx = "0.5"  # For floating point comparisons in tests
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bevy = { version = "0.19", default-features = false, features = [
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-dirs = "5.0"
+dirs = "6.0"
 # Optional: DualSense controller support via HID
 dualsense-rs = { version = "0.6", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_archie"
 version = "0.3.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.96"
 description = "A comprehensive game controller support module for Bevy"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/greysquirr3l/bevy-archie"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Rust](https://img.shields.io/badge/rust-1.93%2B-orange.svg)](https://www.rust-lang.org)
-[![Bevy](https://img.shields.io/badge/bevy-0.18-purple.svg)](https://bevyengine.org)
+[![Bevy](https://img.shields.io/badge/bevy-0.19-purple.svg)](https://bevyengine.org)
 [![Coverage](https://img.shields.io/badge/coverage-66.56%25-yellowgreen.svg)](target/coverage/tarpaulin-report.html)
 [![Following released Bevy versions](https://img.shields.io/badge/Bevy%20tracking-released%20version-lightblue)](https://bevy.org/learn/quick-start/plugin-development/#main-branch-tracking)
 [![crates.io](https://img.shields.io/crates/v/bevy_archie)](https://crates.io/crates/bevy_archie)
@@ -11,7 +11,7 @@
 
 ![Archie Out of Context](docs/assets/archie_context.png)
 
-> **Branch policy:** `main` tracks **Bevy 0.18.x**. The only support branch is [`bevy-0.17`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.17) for **Bevy 0.17.x**, and it is scheduled for retirement on **2026-05-18** (less than 30 days from 2026-04-26).
+> **Branch policy:** `main` tracks **Bevy 0.19.x**. The only support branch is [`bevy-0.18`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.18) for **Bevy 0.18.x**.
 
 A comprehensive game controller support module for the Bevy engine, inspired by the RenPy Controller GUI project.
 
@@ -44,10 +44,11 @@ A comprehensive game controller support module for the Bevy engine, inspired by 
 
 | bevy | bevy_archie                                                                       |
 |------|-----------------------------------------------------------------------------------|
-| 0.18 | 0.2.x (`main`)                                                                    |
+| 0.19 | 0.3.x (`main`)                                                                    |
+| 0.18 | [0.2.x (`bevy-0.18`)](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.18) |
 | 0.17 | [0.1.x (`bevy-0.17`)](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.17) |
 
-> `main` is Bevy 0.18.x. The only other supported line is Bevy 0.17.x on `bevy-0.17`, retiring on **2026-05-18**.
+> `main` is Bevy 0.19.x.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Rust](https://img.shields.io/badge/rust-1.93%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.96%2B-orange.svg)](https://www.rust-lang.org)
 [![Bevy](https://img.shields.io/badge/bevy-0.19-purple.svg)](https://bevyengine.org)
 [![Coverage](https://img.shields.io/badge/coverage-66.56%25-yellowgreen.svg)](target/coverage/tarpaulin-report.html)
 [![Following released Bevy versions](https://img.shields.io/badge/Bevy%20tracking-released%20version-lightblue)](https://bevy.org/learn/quick-start/plugin-development/#main-branch-tracking)
@@ -11,7 +11,7 @@
 
 ![Archie Out of Context](docs/assets/archie_context.png)
 
-> **Branch policy:** `main` tracks **Bevy 0.19.x**. The only support branch is [`bevy-0.18`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.18) for **Bevy 0.18.x**.
+> **Branch policy:** `main` tracks **Bevy 0.19.x**. The maintenance branch is [`bevy-0.18`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.18) for **Bevy 0.18.x**. The [`bevy-0.17`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.17) branch remains published for **Bevy 0.17.x** consumers but is deprecated.
 
 A comprehensive game controller support module for the Bevy engine, inspired by the RenPy Controller GUI project.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ![Archie Out of Context](docs/assets/archie_context.png)
 
-> **Branch policy:** `main` tracks **Bevy 0.19.x**. The maintenance branch is [`bevy-0.18`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.18) for **Bevy 0.18.x**. The [`bevy-0.17`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.17) branch remains published for **Bevy 0.17.x** consumers but is deprecated.
+> **Branch policy:** `main` tracks **Bevy 0.19.x**. The maintenance branch is [`bevy-0.18`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.18) for **Bevy 0.18.x**. Bevy 0.17 support is no longer maintained; the final 0.1.x release remains on [crates.io](https://crates.io/crates/bevy_archie/0.1.4) for existing consumers.
 
 A comprehensive game controller support module for the Bevy engine, inspired by the RenPy Controller GUI project.
 
@@ -46,9 +46,9 @@ A comprehensive game controller support module for the Bevy engine, inspired by 
 |------|-----------------------------------------------------------------------------------|
 | 0.19 | 0.3.x (`main`)                                                                    |
 | 0.18 | [0.2.x (`bevy-0.18`)](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.18) |
-| 0.17 | [0.1.x (`bevy-0.17`)](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.17) |
+| 0.17 | 0.1.x (final, on [crates.io](https://crates.io/crates/bevy_archie/versions))      |
 
-> `main` is Bevy 0.19.x.
+> `main` is Bevy 0.19.x. Bevy 0.17 is no longer maintained; the `bevy-0.17` branch has been retired.
 
 ## Features
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -6,17 +6,16 @@ bevy\_archie follows [Semantic Versioning](https://semver.org/) and maintains co
 
 | Branch | Bevy Version | Status | Crate Version |
 | --- | --- | --- | --- |
-| `main` | 0.18.x | Active Development | 0.2.x |
+| `main` | 0.19.x | Active Development | 0.3.x |
 | `bevy-0.18` | 0.18.x | Maintenance mirror | 0.2.x |
-| `bevy-0.17` | 0.17.x | Deprecated in 30 days (maintenance only) | 0.1.x |
+| `bevy-0.17` | 0.17.x | Deprecated | 0.1.x |
 
 ## Deprecation Notice
 
-Bevy 0.17 support (crate `0.1.x`, branch `bevy-0.17`) is scheduled for deprecation in 30 days.
+Bevy 0.17 support (crate `0.1.x`, branch `bevy-0.17`) is deprecated.
 
-- Deprecation date: 2026-05-18
-- During this window, only critical fixes should target `bevy-0.17`
-- New development should target Bevy 0.18 (`main`, crate `0.2.x`)
+- New development should target Bevy 0.19 (`main`, crate `0.3.x`)
+- Bevy 0.18 maintenance-only patches target `bevy-0.18` (crate `0.2.x`)
 
 ### Branch Lifecycle
 
@@ -29,10 +28,18 @@ Bevy 0.17 support (crate `0.1.x`, branch `bevy-0.17`) is scheduled for deprecati
 
 | bevy\_archie | Bevy | Rust | Notes |
 | --- | --- | --- | --- |
-| 0.2.x | 0.18.x | 1.95+ | Current stable |
-| 0.1.x | 0.17.x | 1.95+ | Deprecated in 30 days |
+| 0.3.x | 0.19.x | 1.96+ | Current stable |
+| 0.2.x | 0.18.x | 1.95+ | Maintenance |
+| 0.1.x | 0.17.x | 1.95+ | Deprecated |
 
 ## Upgrade Path
+
+### From bevy\_archie 0.2.x (Bevy 0.18) to 0.3.x (Bevy 0.19)
+
+Key changes in 0.3.x:
+
+- Updated to Bevy 0.19 APIs (resources-as-components, Parley text, BSN scenes)
+- See the upstream [Bevy 0.18 → 0.19 migration guide](https://bevy.org/learn/migration-guides/0-18-to-0-19/) for details
 
 ### From bevy\_archie 0.1.x (Bevy 0.17) to 0.2.x (Bevy 0.18)
 
@@ -87,11 +94,11 @@ The release workflow automatically:
 Users can select their Bevy version in `Cargo.toml`:
 
 ```toml
-# For Bevy 0.17
+# For Bevy 0.19
 [dependencies]
-bevy_archie = "0.1"
+bevy_archie = "0.3"
 
-# For Bevy 0.18 (when available)
+# For Bevy 0.18
 [dependencies]
 bevy_archie = "0.2"
 ```
@@ -102,4 +109,4 @@ When contributing, target the appropriate branch:
 
 - New features and standard fixes → `main`
 - Bevy 0.18 maintenance-only patches → `bevy-0.18`
-- Bevy 0.17 critical fixes only (until deprecation date) → `bevy-0.17`
+- Bevy 0.17 critical fixes only (deprecated) → `bevy-0.17`

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -8,11 +8,10 @@ bevy\_archie follows [Semantic Versioning](https://semver.org/) and maintains co
 | --- | --- | --- | --- |
 | `main` | 0.19.x | Active Development | 0.3.x |
 | `bevy-0.18` | 0.18.x | Maintenance mirror | 0.2.x |
-| `bevy-0.17` | 0.17.x | Deprecated | 0.1.x |
 
 ## Deprecation Notice
 
-Bevy 0.17 support (crate `0.1.x`, branch `bevy-0.17`) is deprecated.
+Bevy 0.17 support (crate `0.1.x`) is end-of-life. The `bevy-0.17` branch has been retired; the final 0.1.x releases remain on [crates.io](https://crates.io/crates/bevy_archie/versions) for existing consumers.
 
 - New development should target Bevy 0.19 (`main`, crate `0.3.x`)
 - Bevy 0.18 maintenance-only patches target `bevy-0.18` (crate `0.2.x`)
@@ -30,7 +29,6 @@ Bevy 0.17 support (crate `0.1.x`, branch `bevy-0.17`) is deprecated.
 | --- | --- | --- | --- |
 | 0.3.x | 0.19.x | 1.96+ | Current stable |
 | 0.2.x | 0.18.x | 1.95+ | Maintenance |
-| 0.1.x | 0.17.x | 1.95+ | Deprecated |
 
 ## Upgrade Path
 
@@ -109,4 +107,3 @@ When contributing, target the appropriate branch:
 
 - New features and standard fixes → `main`
 - Bevy 0.18 maintenance-only patches → `bevy-0.18`
-- Bevy 0.17 critical fixes only (deprecated) → `bevy-0.17`

--- a/docs/dev/BEVY_0.18_TO_0.19_MIGRATION.md
+++ b/docs/dev/BEVY_0.18_TO_0.19_MIGRATION.md
@@ -1,0 +1,58 @@
+# Migration Guide: bevy\_archie 0.2.x (Bevy 0.18) → 0.3.x (Bevy 0.19)
+
+This release upgrades `bevy_archie` to **Bevy 0.19**. The library API is unchanged — no breaking changes were introduced on the bevy\_archie side. Only the Bevy dependency version bumped and the example code was updated for Bevy 0.19's new APIs.
+
+For the upstream Bevy 0.18 → 0.19 migration notes, see the [official Bevy migration guide](https://bevy.org/learn/migration-guides/0-18-to-0-19/).
+
+## Dependency bump
+
+```toml
+# before
+bevy = { version = "0.18", ... }
+
+# after
+bevy = { version = "0.19", ... }
+```
+
+`bevy_archie` `0.3.x` is the new main line on Bevy 0.19. The previous `0.2.x` line (Bevy 0.18) continues to receive maintenance patches on the [`bevy-0.18`](https://github.com/greysquirr3l/bevy-archie/tree/bevy-0.18) branch.
+
+## Example updates
+
+The only consumer-facing changes in this repo were in the example code, where Bevy 0.19's text overhaul changed the `TextFont` struct:
+
+### `TextFont.font_size` is now a `FontSize` enum
+
+```rust
+// before (Bevy 0.18)
+TextFont {
+    font_size: 24.0,
+    ..default()
+}
+
+// after (Bevy 0.19)
+TextFont {
+    font_size: FontSize::Px(24.0),
+    ..default()
+}
+```
+
+The `FontSize` enum supports `Px`, `Vw`, `Vh`, `VMin`, `VMax`, and `Rem`. The `..default()` form continues to work and resolves to `FontSize::Px(20.0)` (Bevy's previous default).
+
+### `TextFont.font` is now a `FontSource` enum
+
+`Handle<Font>` converts via `From<Handle<Font>>` to `FontSource::Handle`, so existing `..default()` usage is unaffected. New options include `FontSource::Family("name")` for system font discovery and `FontSource::Monospace` / `FontSource::SansSerif` / etc. for semantic font categories.
+
+## Notes for downstream consumers
+
+- **Library code (`src/`) compiles without modification.** No `bevy_archie` types changed.
+- **All 320 unit tests and 17 integration tests pass on Bevy 0.19** unchanged.
+- **No new feature flags were added or removed.** Existing `icons`, `virtual_keyboard`, `remapping`, `motion-backends`, and `dualsense` features continue to work identically.
+- **No `NonSend` resources are used internally.** All internal state moved seamlessly to Bevy 0.19's resources-as-components model.
+
+## Branching model
+
+| Bevy | bevy_archie | Branch |
+|------|-------------|--------|
+| 0.19 | 0.3.x | `main` |
+| 0.18 | 0.2.x | `bevy-0.18` |
+| 0.17 | 0.1.x | `bevy-0.17` (deprecated) |

--- a/docs/dev/BRANCH_WORKFLOW.md
+++ b/docs/dev/BRANCH_WORKFLOW.md
@@ -4,16 +4,17 @@
 
 ## Branch Strategy
 
-Branch policy (effective 2026-04-26): `main` is Bevy 0.18.x. The only other branch line is `bevy-0.17` for Bevy 0.17.x, and that branch is scheduled for retirement on 2026-05-18 (less than 30 days).
+Branch policy (effective 2026-06-22): `main` is Bevy 0.19.x. Maintenance branches are `bevy-0.18` (Bevy 0.18.x) and `bevy-0.17` (Bevy 0.17.x, deprecated).
 
 | Branch | Purpose | Bevy Version | Status |
 | -------- | --------- | -------------- | -------- |
-| `main` | Latest stable release | 0.18.x | Active |
-| `bevy-0.17` | Final maintenance for Bevy 0.17 | 0.17.x | Retirement scheduled for 2026-05-18 |
+| `main` | Latest stable release | 0.19.x | Active |
+| `bevy-0.18` | Maintenance for Bevy 0.18 | 0.18.x | Maintenance |
+| `bevy-0.17` | Final maintenance for Bevy 0.17 | 0.17.x | Deprecated |
 
 ## Backport Strategy
 
-There is no automatic `sync-branches.yml` workflow in this repository. Backports from `main` to `bevy-0.17` are manual cherry-picks when needed.
+There is no automatic `sync-branches.yml` workflow in this repository. Backports from `main` to `bevy-0.18` and `bevy-0.17` are manual cherry-picks when needed.
 
 ### How It Works
 
@@ -62,7 +63,7 @@ git checkout main
 
 | Workflow | Trigger | Purpose |
 | ---------- | --------- | --------- |
-| `ci.yml` | Push/PR to main, bevy-0.17 | Check, Test, Clippy, Format, Docs, MSRV |
+| `ci.yml` | Push/PR to main, bevy-0.18, bevy-0.17 | Check, Test, Clippy, Format, Docs, MSRV |
 | `security.yml` | Push/PR, weekly schedule | cargo-audit, cargo-deny |
 | `codeql.yml` | Push/PR, weekly schedule | Security analysis |
 | `release.yml` | Tag v*.*.* | Publish to crates.io |
@@ -70,7 +71,7 @@ git checkout main
 
 ## Branch Protection
 
-Both `main` and `bevy-0.17` have OSSF branch protection:
+`main`, `bevy-0.18`, and `bevy-0.17` have OSSF branch protection:
 
 - **Required status checks:** Check, Test, Clippy, Format
 - **Strict status checks:** Branch must be up-to-date
@@ -83,13 +84,14 @@ Both `main` and `bevy-0.17` have OSSF branch protection:
 - **Cargo updates:** Weekly on Monday 9 AM ET
 - **GitHub Actions updates:** Weekly on Monday 9 AM ET
 - **Bevy updates:** Ignored (manual migration required)
-- **Target branches:** main, bevy-0.17
+- **Target branches:** main, bevy-0.18, bevy-0.17
 
 ## MSRV (Minimum Supported Rust Version)
 
 | Branch | MSRV | Notes |
 | -------- | ------ | ------- |
 | main | 1.94 | Matches `rust-version` in `Cargo.toml` on `main` |
+| bevy-0.18 | Branch-specific | Check that branch's `Cargo.toml` |
 | bevy-0.17 | Branch-specific | Check that branch's `Cargo.toml` |
 
 ## Bevy Migration Process
@@ -99,10 +101,10 @@ When migrating to a new Bevy version:
 1. Create/checkout the `bevy-0.XX` branch
 2. Update `Cargo.toml` with new Bevy version
 3. Update MSRV in `Cargo.toml` and `ci.yml`
-4. Fix breaking changes (see `docs/dev/BEVY_0.17_TO_0.18_MIGRATION.md`)
+4. Fix breaking changes (see the Bevy release notes and upstream migration guide for that version)
 5. Run full test suite
 6. Update `CHANGELOG.md`
-7. Keep `main` as the Bevy 0.18.x line and retire obsolete support branches on schedule
+7. Keep `main` as the latest Bevy release line and demote the previous release line to a `bevy-0.XX` maintenance branch
 
 ## Publishing to crates.io
 

--- a/docs/dev/BRANCH_WORKFLOW.md
+++ b/docs/dev/BRANCH_WORKFLOW.md
@@ -4,23 +4,22 @@
 
 ## Branch Strategy
 
-Branch policy (effective 2026-06-22): `main` is Bevy 0.19.x. Maintenance branches are `bevy-0.18` (Bevy 0.18.x) and `bevy-0.17` (Bevy 0.17.x, deprecated).
+Branch policy (effective 2026-06-22): `main` is Bevy 0.19.x. The maintenance branch is `bevy-0.18` (Bevy 0.18.x). Bevy 0.17 support is end-of-life and the `bevy-0.17` branch has been retired; final 0.1.x releases remain on crates.io.
 
 | Branch | Purpose | Bevy Version | Status |
 | -------- | --------- | -------------- | -------- |
 | `main` | Latest stable release | 0.19.x | Active |
 | `bevy-0.18` | Maintenance for Bevy 0.18 | 0.18.x | Maintenance |
-| `bevy-0.17` | Final maintenance for Bevy 0.17 | 0.17.x | Deprecated |
 
 ## Backport Strategy
 
-There is no automatic `sync-branches.yml` workflow in this repository. Backports from `main` to `bevy-0.18` and `bevy-0.17` are manual cherry-picks when needed.
+There is no automatic `sync-branches.yml` workflow in this repository. Backports from `main` to `bevy-0.18` are manual cherry-picks when needed.
 
 ### How It Works
 
 1. Push a commit to `main`
-2. Decide whether the change should also ship on `bevy-0.18` or `bevy-0.17`
-3. Cherry-pick the commit onto the target maintenance branch(es)
+2. Decide whether the change should also ship on `bevy-0.18`
+3. Cherry-pick the commit onto `bevy-0.18`
 4. Resolve conflicts locally if they occur
 
 ### Skipping Sync
@@ -42,7 +41,7 @@ If you need to manually sync (e.g., conflict resolution):
 git push origin main
 
 # Switch to target branch
-git checkout bevy-0.18   # or bevy-0.17
+git checkout bevy-0.18
 
 # Cherry-pick the commit
 git cherry-pick <commit-sha>
@@ -53,7 +52,7 @@ git cherry-pick <commit-sha>
 # 3. git cherry-pick --continue
 
 # Push
-git push origin bevy-0.18   # or bevy-0.17
+git push origin bevy-0.18
 
 # Return to main
 git checkout main
@@ -63,7 +62,7 @@ git checkout main
 
 | Workflow | Trigger | Purpose |
 | ---------- | --------- | --------- |
-| `ci.yml` | Push/PR to main, bevy-0.18, bevy-0.17 | Check, Test, Clippy, Format, Docs, MSRV |
+| `ci.yml` | Push/PR to main, bevy-0.18 | Check, Test, Clippy, Format, Docs, MSRV |
 | `security.yml` | Push/PR, weekly schedule | cargo-audit, cargo-deny |
 | `codeql.yml` | Push/PR, weekly schedule | Security analysis |
 | `release.yml` | Tag v*.*.* | Publish to crates.io |
@@ -71,7 +70,7 @@ git checkout main
 
 ## Branch Protection
 
-`main`, `bevy-0.18`, and `bevy-0.17` have OSSF branch protection:
+`main` and `bevy-0.18` have OSSF branch protection:
 
 - **Required status checks:** Check, Test, Clippy, Format
 - **Strict status checks:** Branch must be up-to-date
@@ -84,7 +83,7 @@ git checkout main
 - **Cargo updates:** Weekly on Monday 9 AM ET
 - **GitHub Actions updates:** Weekly on Monday 9 AM ET
 - **Bevy updates:** Ignored (manual migration required)
-- **Target branches:** main, bevy-0.18, bevy-0.17
+- **Target branches:** main, bevy-0.18
 
 ## MSRV (Minimum Supported Rust Version)
 
@@ -92,7 +91,6 @@ git checkout main
 | -------- | ------ | ------- |
 | main | 1.96 | Matches `rust-version` in `Cargo.toml` on `main` |
 | bevy-0.18 | Branch-specific | Check that branch's `Cargo.toml` |
-| bevy-0.17 | Branch-specific | Check that branch's `Cargo.toml` |
 
 ## Bevy Migration Process
 

--- a/docs/dev/BRANCH_WORKFLOW.md
+++ b/docs/dev/BRANCH_WORKFLOW.md
@@ -19,8 +19,8 @@ There is no automatic `sync-branches.yml` workflow in this repository. Backports
 ### How It Works
 
 1. Push a commit to `main`
-2. Decide whether the change should also ship on `bevy-0.17`
-3. Cherry-pick the commit onto `bevy-0.17`
+2. Decide whether the change should also ship on `bevy-0.18` or `bevy-0.17`
+3. Cherry-pick the commit onto the target maintenance branch(es)
 4. Resolve conflicts locally if they occur
 
 ### Skipping Sync
@@ -42,7 +42,7 @@ If you need to manually sync (e.g., conflict resolution):
 git push origin main
 
 # Switch to target branch
-git checkout bevy-0.17
+git checkout bevy-0.18   # or bevy-0.17
 
 # Cherry-pick the commit
 git cherry-pick <commit-sha>
@@ -53,7 +53,7 @@ git cherry-pick <commit-sha>
 # 3. git cherry-pick --continue
 
 # Push
-git push origin bevy-0.17
+git push origin bevy-0.18   # or bevy-0.17
 
 # Return to main
 git checkout main
@@ -90,7 +90,7 @@ git checkout main
 
 | Branch | MSRV | Notes |
 | -------- | ------ | ------- |
-| main | 1.94 | Matches `rust-version` in `Cargo.toml` on `main` |
+| main | 1.96 | Matches `rust-version` in `Cargo.toml` on `main` |
 | bevy-0.18 | Branch-specific | Check that branch's `Cargo.toml` |
 | bevy-0.17 | Branch-specific | Check that branch's `Cargo.toml` |
 

--- a/examples/basic_input.rs
+++ b/examples/basic_input.rs
@@ -7,6 +7,7 @@
 //! Basic input example demonstrating controller detection and action mapping.
 
 use bevy::prelude::*;
+use bevy::text::LetterSpacing;
 use bevy_archie::prelude::*;
 
 fn main() {
@@ -46,16 +47,20 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Bevy Archie - Controller Support Demo"),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(32.0),
+                    weight: FontWeight::BOLD,
                     ..default()
                 },
                 TextColor(Color::WHITE),
+                LetterSpacing::Px(1.0),
             ));
 
             // Input state display
             parent.spawn((
                 Text::new("Input Device: Mouse"),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(24.0),
                     ..default()
                 },
@@ -67,6 +72,7 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Actions: None"),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(20.0),
                     ..default()
                 },
@@ -83,6 +89,7 @@ fn setup(mut commands: Commands) {
                      - Press buttons to see action states",
                 ),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(18.0),
                     ..default()
                 },

--- a/examples/basic_input.rs
+++ b/examples/basic_input.rs
@@ -46,7 +46,7 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Bevy Archie - Controller Support Demo"),
                 TextFont {
-                    font_size: 32.0,
+                    font_size: FontSize::Px(32.0),
                     ..default()
                 },
                 TextColor(Color::WHITE),
@@ -56,7 +56,7 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Input Device: Mouse"),
                 TextFont {
-                    font_size: 24.0,
+                    font_size: FontSize::Px(24.0),
                     ..default()
                 },
                 TextColor(Color::srgb(0.7, 0.7, 0.7)),
@@ -67,7 +67,7 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Actions: None"),
                 TextFont {
-                    font_size: 20.0,
+                    font_size: FontSize::Px(20.0),
                     ..default()
                 },
                 TextColor(Color::srgb(0.5, 0.8, 0.5)),
@@ -83,7 +83,7 @@ fn setup(mut commands: Commands) {
                      - Press buttons to see action states",
                 ),
                 TextFont {
-                    font_size: 18.0,
+                    font_size: FontSize::Px(18.0),
                     ..default()
                 },
                 TextColor(Color::srgb(0.6, 0.6, 0.6)),

--- a/examples/config_persistence.rs
+++ b/examples/config_persistence.rs
@@ -75,7 +75,7 @@ fn setup(mut commands: Commands) {
             ..default()
         },
         TextFont {
-            font_size: 18.0,
+            font_size: FontSize::Px(18.0),
             ..default()
         },
         TextColor(Color::WHITE),

--- a/examples/config_persistence.rs
+++ b/examples/config_persistence.rs
@@ -10,6 +10,7 @@
 //! - X-axis inversion options
 
 use bevy::prelude::*;
+use bevy::text::LetterSpacing;
 use bevy_archie::prelude::*;
 
 fn main() {
@@ -75,10 +76,12 @@ fn setup(mut commands: Commands) {
             ..default()
         },
         TextFont {
+            font: FontSource::SansSerif,
             font_size: FontSize::Px(18.0),
             ..default()
         },
         TextColor(Color::WHITE),
+        LetterSpacing::Px(0.5),
     ));
 }
 

--- a/examples/controller_database.rs
+++ b/examples/controller_database.rs
@@ -29,7 +29,7 @@ fn setup(mut commands: Commands) {
             "Controller Detection Database Example\n\nConnect a controller to see its details...",
         ),
         TextFont {
-            font_size: 24.0,
+            font_size: FontSize::Px(24.0),
             ..default()
         },
         TextColor(Color::WHITE),

--- a/examples/controller_database.rs
+++ b/examples/controller_database.rs
@@ -29,6 +29,7 @@ fn setup(mut commands: Commands) {
             "Controller Detection Database Example\n\nConnect a controller to see its details...",
         ),
         TextFont {
+            font: FontSource::SansSerif,
             font_size: FontSize::Px(24.0),
             ..default()
         },

--- a/examples/controller_icons.rs
+++ b/examples/controller_icons.rs
@@ -51,7 +51,7 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Controller Icon Demo"),
                 TextFont {
-                    font_size: 32.0,
+                    font_size: FontSize::Px(32.0),
                     ..default()
                 },
                 TextColor(Color::WHITE),
@@ -61,7 +61,7 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Layout: Xbox"),
                 TextFont {
-                    font_size: 24.0,
+                    font_size: FontSize::Px(24.0),
                     ..default()
                 },
                 TextColor(Color::srgb(0.7, 0.7, 0.7)),
@@ -102,7 +102,7 @@ fn setup(mut commands: Commands) {
                     "Press 1-4 to change layout:\n1=Xbox, 2=PlayStation, 3=Nintendo, 4=Generic",
                 ),
                 TextFont {
-                    font_size: 18.0,
+                    font_size: FontSize::Px(18.0),
                     ..default()
                 },
                 TextColor(Color::srgb(0.5, 0.5, 0.5)),
@@ -137,7 +137,7 @@ fn spawn_button_prompt(parent: &mut ChildSpawnerCommands, icon: ButtonIcon, labe
                 button.spawn((
                     Text::new(icon.label(ControllerLayout::Xbox)),
                     TextFont {
-                        font_size: 20.0,
+                        font_size: FontSize::Px(20.0),
                         ..default()
                     },
                     TextColor(Color::WHITE),
@@ -148,7 +148,7 @@ fn spawn_button_prompt(parent: &mut ChildSpawnerCommands, icon: ButtonIcon, labe
             col.spawn((
                 Text::new(label),
                 TextFont {
-                    font_size: 16.0,
+                    font_size: FontSize::Px(16.0),
                     ..default()
                 },
                 TextColor(Color::srgb(0.8, 0.8, 0.8)),

--- a/examples/controller_icons.rs
+++ b/examples/controller_icons.rs
@@ -1,6 +1,7 @@
 //! Controller icons example showing how to display button prompts.
 
 use bevy::prelude::*;
+use bevy::text::LetterSpacing;
 use bevy_archie::icons::ButtonIcon;
 use bevy_archie::prelude::*;
 
@@ -51,16 +52,20 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Controller Icon Demo"),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(32.0),
+                    weight: FontWeight::BOLD,
                     ..default()
                 },
                 TextColor(Color::WHITE),
+                LetterSpacing::Px(1.0),
             ));
 
             // Layout indicator
             parent.spawn((
                 Text::new("Layout: Xbox"),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(24.0),
                     ..default()
                 },
@@ -102,6 +107,7 @@ fn setup(mut commands: Commands) {
                     "Press 1-4 to change layout:\n1=Xbox, 2=PlayStation, 3=Nintendo, 4=Generic",
                 ),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(18.0),
                     ..default()
                 },
@@ -137,7 +143,9 @@ fn spawn_button_prompt(parent: &mut ChildSpawnerCommands, icon: ButtonIcon, labe
                 button.spawn((
                     Text::new(icon.label(ControllerLayout::Xbox)),
                     TextFont {
+                        font: FontSource::Monospace,
                         font_size: FontSize::Px(20.0),
+                        weight: FontWeight::BOLD,
                         ..default()
                     },
                     TextColor(Color::WHITE),
@@ -148,6 +156,7 @@ fn spawn_button_prompt(parent: &mut ChildSpawnerCommands, icon: ButtonIcon, labe
             col.spawn((
                 Text::new(label),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(16.0),
                     ..default()
                 },

--- a/examples/remapping.rs
+++ b/examples/remapping.rs
@@ -153,10 +153,10 @@ fn spawn_remap_row(parent: &mut ChildSpawnerCommands, action: GameAction) {
             .with_children(|btn: &mut ChildSpawnerCommands| {
                 btn.spawn((
                     Text::new("Remap"),
-                        TextFont {
-                            font_size: FontSize::Px(14.0),
-                            ..default()
-                        },
+                    TextFont {
+                        font_size: FontSize::Px(14.0),
+                        ..default()
+                    },
                     TextColor(Color::WHITE),
                 ));
             });

--- a/examples/remapping.rs
+++ b/examples/remapping.rs
@@ -43,7 +43,7 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Controller Remapping"),
                 TextFont {
-                    font_size: 32.0,
+                    font_size: FontSize::Px(32.0),
                     ..default()
                 },
                 TextColor(Color::WHITE),
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Click an action to remap it, then press a button on your controller"),
                 TextFont {
-                    font_size: 18.0,
+                    font_size: FontSize::Px(18.0),
                     ..default()
                 },
                 TextColor(Color::srgb(0.6, 0.6, 0.6)),
@@ -91,7 +91,7 @@ fn setup(mut commands: Commands) {
                     btn.spawn((
                         Text::new("Reset to Defaults"),
                         TextFont {
-                            font_size: 16.0,
+                            font_size: FontSize::Px(16.0),
                             ..default()
                         },
                         TextColor(Color::WHITE),
@@ -113,7 +113,7 @@ fn spawn_remap_row(parent: &mut ChildSpawnerCommands, action: GameAction) {
             row.spawn((
                 Text::new(action.display_name()),
                 TextFont {
-                    font_size: 20.0,
+                    font_size: FontSize::Px(20.0),
                     ..default()
                 },
                 TextColor(Color::WHITE),
@@ -127,7 +127,7 @@ fn spawn_remap_row(parent: &mut ChildSpawnerCommands, action: GameAction) {
             row.spawn((
                 Text::new("[A]"),
                 TextFont {
-                    font_size: 18.0,
+                    font_size: FontSize::Px(18.0),
                     ..default()
                 },
                 TextColor(Color::srgb(0.7, 0.7, 0.7)),
@@ -153,10 +153,10 @@ fn spawn_remap_row(parent: &mut ChildSpawnerCommands, action: GameAction) {
             .with_children(|btn: &mut ChildSpawnerCommands| {
                 btn.spawn((
                     Text::new("Remap"),
-                    TextFont {
-                        font_size: 14.0,
-                        ..default()
-                    },
+                        TextFont {
+                            font_size: FontSize::Px(14.0),
+                            ..default()
+                        },
                     TextColor(Color::WHITE),
                 ));
             });

--- a/examples/remapping.rs
+++ b/examples/remapping.rs
@@ -163,11 +163,11 @@ fn spawn_remap_row(parent: &mut ChildSpawnerCommands, action: GameAction) {
             .with_children(|btn: &mut ChildSpawnerCommands| {
                 btn.spawn((
                     Text::new("Remap"),
-                        TextFont {
-                            font: FontSource::SansSerif,
-                            font_size: FontSize::Px(14.0),
-                            ..default()
-                        },
+                    TextFont {
+                        font: FontSource::SansSerif,
+                        font_size: FontSize::Px(14.0),
+                        ..default()
+                    },
                     TextColor(Color::WHITE),
                 ));
             });

--- a/examples/remapping.rs
+++ b/examples/remapping.rs
@@ -3,6 +3,7 @@
 //! Controller remapping example.
 
 use bevy::prelude::*;
+use bevy::text::LetterSpacing;
 use bevy_archie::prelude::*;
 
 fn main() {
@@ -43,16 +44,20 @@ fn setup(mut commands: Commands) {
             parent.spawn((
                 Text::new("Controller Remapping"),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(32.0),
+                    weight: FontWeight::BOLD,
                     ..default()
                 },
                 TextColor(Color::WHITE),
+                LetterSpacing::Px(1.0),
             ));
 
             // Status text
             parent.spawn((
                 Text::new("Click an action to remap it, then press a button on your controller"),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(18.0),
                     ..default()
                 },
@@ -91,7 +96,9 @@ fn setup(mut commands: Commands) {
                     btn.spawn((
                         Text::new("Reset to Defaults"),
                         TextFont {
+                            font: FontSource::SansSerif,
                             font_size: FontSize::Px(16.0),
+                            weight: FontWeight::BOLD,
                             ..default()
                         },
                         TextColor(Color::WHITE),
@@ -113,7 +120,9 @@ fn spawn_remap_row(parent: &mut ChildSpawnerCommands, action: GameAction) {
             row.spawn((
                 Text::new(action.display_name()),
                 TextFont {
+                    font: FontSource::SansSerif,
                     font_size: FontSize::Px(20.0),
+                    weight: FontWeight::SEMIBOLD,
                     ..default()
                 },
                 TextColor(Color::WHITE),
@@ -127,6 +136,7 @@ fn spawn_remap_row(parent: &mut ChildSpawnerCommands, action: GameAction) {
             row.spawn((
                 Text::new("[A]"),
                 TextFont {
+                    font: FontSource::Monospace,
                     font_size: FontSize::Px(18.0),
                     ..default()
                 },
@@ -154,6 +164,7 @@ fn spawn_remap_row(parent: &mut ChildSpawnerCommands, action: GameAction) {
                 btn.spawn((
                     Text::new("Remap"),
                         TextFont {
+                            font: FontSource::SansSerif,
                             font_size: FontSize::Px(14.0),
                             ..default()
                         },

--- a/examples/virtual_cursor.rs
+++ b/examples/virtual_cursor.rs
@@ -93,6 +93,7 @@ fn setup(
             ..default()
         },
         TextFont {
+            font: FontSource::SansSerif,
             font_size: FontSize::Px(20.0),
             ..default()
         },

--- a/examples/virtual_cursor.rs
+++ b/examples/virtual_cursor.rs
@@ -93,7 +93,7 @@ fn setup(
             ..default()
         },
         TextFont {
-            font_size: 20.0,
+            font_size: FontSize::Px(20.0),
             ..default()
         },
         TextColor(Color::WHITE),


### PR DESCRIPTION
Promotes the Bevy 0.19 line to main.

This PR brings in the Bevy 0.19 upgrade and the example typography follow-up that was developed on the `bevy-0.19` and `feat/bevy-0.19-improvements` branches.

### Bevy 0.19 upgrade (`0523422`)
- `bevy` dependency bumped 0.18 -> 0.19
- API updates for the new Bevy release

### `dirs` dependency bump (`6ffeda7`)
- `dirs` 5.0 -> 6.0

### Example typography follow-up (`a4b99ac`)
- Replace default font handle with semantic `FontSource` variants:
  - `SansSerif` for general UI text
  - `Monospace` for button labels and binding displays
  - `BOLD` / `SEMIBOLD` weights for titles and prominent labels
- Add `LetterSpacing::Px` to titles for readability
- Enable `bevy_scene` and `bevy_settings` features needed by the examples

Clippy clean; no behavior change beyond typography.

---

After this lands, `main` continues to track Bevy 0.19.x per the branch policy documented in the README.